### PR TITLE
Add admin mode with teacher authentication (fixes #5)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -5,10 +5,14 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Depends
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 import os
+import json
+import hashlib
+import secrets
 from pathlib import Path
 
 app = FastAPI(title="Mergington High School API",
@@ -18,6 +22,26 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+# Load teacher credentials from teachers.json
+TEACHERS_FILE = current_dir / "teachers.json"
+
+def load_teachers():
+    with open(TEACHERS_FILE) as f:
+        return json.load(f)["teachers"]
+
+def hash_password(password: str) -> str:
+    return hashlib.sha256(password.encode()).hexdigest()
+
+# In-memory active sessions: token -> username
+active_sessions: dict[str, str] = {}
+
+bearer_scheme = HTTPBearer(auto_error=False)
+
+def get_current_teacher(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)):
+    if credentials is None or credentials.credentials not in active_sessions:
+        raise HTTPException(status_code=401, detail="Authentication required")
+    return active_sessions[credentials.credentials]
 
 # In-memory activity database
 activities = {
@@ -83,13 +107,34 @@ def root():
     return RedirectResponse(url="/static/index.html")
 
 
+@app.post("/login")
+def login(username: str, password: str):
+    """Authenticate a teacher and return a session token"""
+    teachers = load_teachers()
+    hashed = hash_password(password)
+    for teacher in teachers:
+        if teacher["username"] == username and teacher["password"] == hashed:
+            token = secrets.token_hex(32)
+            active_sessions[token] = username
+            return {"token": token, "username": username}
+    raise HTTPException(status_code=401, detail="Invalid username or password")
+
+
+@app.post("/logout")
+def logout(credentials: HTTPAuthorizationCredentials = Depends(bearer_scheme)):
+    """Invalidate the current session token"""
+    if credentials and credentials.credentials in active_sessions:
+        del active_sessions[credentials.credentials]
+    return {"message": "Logged out successfully"}
+
+
 @app.get("/activities")
 def get_activities():
     return activities
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
+def signup_for_activity(activity_name: str, email: str, teacher: str = Depends(get_current_teacher)):
     """Sign up a student for an activity"""
     # Validate activity exists
     if activity_name not in activities:
@@ -111,7 +156,7 @@ def signup_for_activity(activity_name: str, email: str):
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
+def unregister_from_activity(activity_name: str, email: str, teacher: str = Depends(get_current_teacher)):
     """Unregister a student from an activity"""
     # Validate activity exists
     if activity_name not in activities:

--- a/src/static/app.js
+++ b/src/static/app.js
@@ -4,6 +4,92 @@ document.addEventListener("DOMContentLoaded", () => {
   const signupForm = document.getElementById("signup-form");
   const messageDiv = document.getElementById("message");
 
+  // Auth elements
+  const authBtn = document.getElementById("auth-btn");
+  const logoutBtn = document.getElementById("logout-btn");
+  const loggedInLabel = document.getElementById("logged-in-label");
+  const loginModal = document.getElementById("login-modal");
+  const loginForm = document.getElementById("login-form");
+  const loginError = document.getElementById("login-error");
+  const cancelLogin = document.getElementById("cancel-login");
+  const signupContainer = document.getElementById("signup-container");
+
+  // --- Auth state ---
+  function getToken() { return sessionStorage.getItem("teacherToken"); }
+  function getUsername() { return sessionStorage.getItem("teacherUsername"); }
+  function isLoggedIn() { return !!getToken(); }
+
+  function applyAuthState() {
+    const loggedIn = isLoggedIn();
+    authBtn.classList.toggle("hidden", loggedIn);
+    logoutBtn.classList.toggle("hidden", !loggedIn);
+    loggedInLabel.classList.toggle("hidden", !loggedIn);
+    if (loggedIn) loggedInLabel.textContent = `👤 ${getUsername()}`;
+    signupContainer.classList.toggle("hidden", !loggedIn);
+    // Show/hide delete buttons
+    document.querySelectorAll(".delete-btn").forEach(btn => {
+      btn.classList.toggle("hidden", !loggedIn);
+    });
+  }
+
+  // Open login modal
+  authBtn.addEventListener("click", () => {
+    loginModal.classList.remove("hidden");
+    loginError.classList.add("hidden");
+    loginForm.reset();
+  });
+
+  // Close login modal
+  cancelLogin.addEventListener("click", () => {
+    loginModal.classList.add("hidden");
+  });
+
+  // Close modal when clicking the backdrop
+  loginModal.addEventListener("click", (e) => {
+    if (e.target === loginModal) loginModal.classList.add("hidden");
+  });
+
+  // Handle login form submit
+  loginForm.addEventListener("submit", async (e) => {
+    e.preventDefault();
+    const username = document.getElementById("username").value;
+    const password = document.getElementById("password").value;
+    try {
+      const response = await fetch(
+        `/login?username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}`,
+        { method: "POST" }
+      );
+      if (response.ok) {
+        const data = await response.json();
+        sessionStorage.setItem("teacherToken", data.token);
+        sessionStorage.setItem("teacherUsername", data.username);
+        loginModal.classList.add("hidden");
+        applyAuthState();
+      } else {
+        const err = await response.json();
+        loginError.textContent = err.detail || "Login failed";
+        loginError.classList.remove("hidden");
+      }
+    } catch {
+      loginError.textContent = "Login failed. Please try again.";
+      loginError.classList.remove("hidden");
+    }
+  });
+
+  // Handle logout
+  logoutBtn.addEventListener("click", async () => {
+    const token = getToken();
+    if (token) {
+      await fetch("/logout", {
+        method: "POST",
+        headers: { "Authorization": `Bearer ${token}` }
+      });
+    }
+    sessionStorage.removeItem("teacherToken");
+    sessionStorage.removeItem("teacherUsername");
+    applyAuthState();
+  });
+
   // Function to fetch activities from API
   async function fetchActivities() {
     try {
@@ -30,7 +116,7 @@ document.addEventListener("DOMContentLoaded", () => {
                 ${details.participants
                   .map(
                     (email) =>
-                      `<li><span class="participant-email">${email}</span><button class="delete-btn" data-activity="${name}" data-email="${email}">❌</button></li>`
+                      `<li><span class="participant-email">${email}</span><button class="delete-btn${isLoggedIn() ? "" : " hidden"}" data-activity="${name}" data-email="${email}">❌</button></li>`
                   )
                   .join("")}
               </ul>
@@ -60,6 +146,8 @@ document.addEventListener("DOMContentLoaded", () => {
       document.querySelectorAll(".delete-btn").forEach((button) => {
         button.addEventListener("click", handleUnregister);
       });
+
+      applyAuthState();
     } catch (error) {
       activitiesList.innerHTML =
         "<p>Failed to load activities. Please try again later.</p>";
@@ -80,6 +168,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/unregister?email=${encodeURIComponent(email)}`,
         {
           method: "DELETE",
+          headers: { "Authorization": `Bearer ${getToken()}` }
         }
       );
 
@@ -124,6 +213,7 @@ document.addEventListener("DOMContentLoaded", () => {
         )}/signup?email=${encodeURIComponent(email)}`,
         {
           method: "POST",
+          headers: { "Authorization": `Bearer ${getToken()}` }
         }
       );
 
@@ -156,5 +246,6 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   // Initialize app
+  applyAuthState();
   fetchActivities();
 });

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -10,7 +10,34 @@
     <header>
       <h1>Mergington High School</h1>
       <h2>Extracurricular Activities</h2>
+      <div id="auth-widget">
+        <span id="logged-in-label" class="hidden"></span>
+        <button id="auth-btn" title="Teacher Login">&#128100; Login</button>
+        <button id="logout-btn" class="hidden" title="Logout">Logout</button>
+      </div>
     </header>
+
+    <!-- Login Modal -->
+    <div id="login-modal" class="modal hidden">
+      <div class="modal-content">
+        <h3>Teacher Login</h3>
+        <form id="login-form">
+          <div class="form-group">
+            <label for="username">Username:</label>
+            <input type="text" id="username" required autocomplete="username" />
+          </div>
+          <div class="form-group">
+            <label for="password">Password:</label>
+            <input type="password" id="password" required autocomplete="current-password" />
+          </div>
+          <div id="login-error" class="error hidden"></div>
+          <div class="modal-actions">
+            <button type="submit">Login</button>
+            <button type="button" id="cancel-login">Cancel</button>
+          </div>
+        </form>
+      </div>
+    </div>
 
     <main>
       <section id="activities-container">

--- a/src/static/styles.css
+++ b/src/static/styles.css
@@ -22,6 +22,77 @@ header {
   background-color: #1a237e;
   color: white;
   border-radius: 5px;
+  position: relative;
+}
+
+#auth-widget {
+  position: absolute;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+#logged-in-label {
+  color: #c5cae9;
+  font-size: 14px;
+}
+
+#auth-btn, #logout-btn {
+  background-color: rgba(255,255,255,0.15);
+  color: white;
+  border: 1px solid rgba(255,255,255,0.4);
+  padding: 6px 12px;
+  font-size: 14px;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: background-color 0.2s;
+}
+
+#auth-btn:hover, #logout-btn:hover {
+  background-color: rgba(255,255,255,0.3);
+}
+
+/* Login Modal */
+.modal {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+
+.modal-content {
+  background: white;
+  padding: 30px;
+  border-radius: 8px;
+  width: 100%;
+  max-width: 360px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+}
+
+.modal-content h3 {
+  margin-bottom: 20px;
+  color: #1a237e;
+}
+
+.modal-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 16px;
+}
+
+.modal-actions button[type="button"] {
+  background-color: #e0e0e0;
+  color: #333;
+}
+
+.modal-actions button[type="button"]:hover {
+  background-color: #bdbdbd;
 }
 
 header h1 {

--- a/src/teachers.json
+++ b/src/teachers.json
@@ -1,0 +1,12 @@
+{
+  "teachers": [
+    {
+      "username": "msmith",
+      "password": "b520ef7e4123c1410729d4574d1e5ef0aa5bfda601f3fbc6f7a7387fba90ebcb"
+    },
+    {
+      "username": "admin",
+      "password": "240be518fabd2724ddb6f04eeb1da5967448d7e831c08c8fa822809f74c720a9"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Fixes #5 — Students were removing each other from activities to free up spots. This PR adds a teacher-only authentication system so only logged-in teachers can register or unregister students.

## Changes

### Backend (`src/app.py`)
- `POST /login` — validates username/password against `teachers.json` (SHA-256 hashed), returns a secure session token
- `POST /logout` — invalidates the session token
- `POST /activities/{name}/signup` and `DELETE /activities/{name}/unregister` now require a valid Bearer token

### New file (`src/teachers.json`)
- Stores teacher credentials as SHA-256 hashes
- Pre-configured accounts: `msmith` and `admin`

### Frontend (`src/static/`)
- User icon + Login/Logout buttons in the top-right corner of the header
- Login modal with username/password form and error feedback
- Signup form and ❌ unregister buttons are **hidden from students** and only visible when a teacher is logged in
- All mutating API calls send `Authorization: Bearer <token>`

## Behavior
- **Students (not logged in):** Can view all activities and participant lists, but cannot register or unregister anyone
- **Teachers (logged in):** Full access to register and unregister students